### PR TITLE
Suppress cppcheck warnings for nanobind headers

### DIFF
--- a/cppcheck-suppressions.txt
+++ b/cppcheck-suppressions.txt
@@ -48,3 +48,8 @@ unusedStructMember
 
 // Suppress checks on external deps like units
 *:*build/_deps/*
+
+// Suppress checks on nanobind's headers (including its bundled tsl::robin_map).
+// cppcheck's preprocessor does not fully evaluate the version macros there,
+// which can trip the library's own `#error` version check as a false positive.
+*:*/nanobind/*


### PR DESCRIPTION
## Summary
Added cppcheck suppression rules for nanobind headers to prevent false positive errors during static analysis.

## Changes
- Extended `cppcheck-suppressions.txt` to exclude nanobind headers from cppcheck analysis
- Added explanatory comment documenting why the suppression is necessary: cppcheck's preprocessor does not fully evaluate version macros in nanobind, causing false positives when the library's own `#error` version check is triggered

## Details
This suppression applies to all files under any `nanobind/` directory path, which includes nanobind's own headers and its bundled `tsl::robin_map` dependency. This prevents spurious cppcheck failures during the build process without affecting analysis of the project's own code.

https://claude.ai/code/session_01YSQsa7g25UFC68vxkcZqFX